### PR TITLE
Dev/lprobsth enhance

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -359,7 +359,7 @@ class admin_plugin_doxycode extends AdminPlugin {
             $form->addTagClose('td');
 
             $form->addTagOpen('td');
-            $form->addTextInput('tag_config[' . $key . '][description]')
+            $form->addTextInput('tag_config[new][description]')
                 ->attrs(['size' => $this->conf_column_widths['description']])
                 ->useInput(false);
             $form->addTagClose('td');

--- a/helper/tagmanager.php
+++ b/helper/tagmanager.php
@@ -86,6 +86,10 @@ class helper_plugin_doxycode_tagmanager extends Plugin {
 
         $selectedKeys = [];
 
+        if(!is_dir($this->tagfile_dir)) {
+            mkdir($this->tagfile_dir);
+        }
+
         $config_filename = $this->tagfile_dir . 'tagconfig.json';
 
         // loop over all configuration entries

--- a/remote.php
+++ b/remote.php
@@ -1,0 +1,97 @@
+<?php
+
+use dokuwiki\Extension\RemotePlugin;
+use dokuwiki\Remote\AccessDeniedException;
+
+/**
+ * Class remote_plugin_acl
+ */
+class remote_plugin_doxycode extends RemotePlugin
+{
+
+    /**
+     * Returns details about the remote plugin methods
+     *
+     * @return array Information about all provided methods. {@see dokuwiki\Remote\RemoteAPI}
+     */
+    public function _getMethods()
+    {
+        return array(
+            'listTagFiles' => array(
+                'args' => array(),
+                'return' => 'Array of Tag Files',
+                'doc' => 'Get the list of all ACLs',
+            ),'uploadTagFile' => array(
+                'args' => array('string', 'file', 'array'),
+                'return' => 'int',
+                'name' => 'uploadTagFile',
+                'doc' => 'Adds a new ACL rule.'
+            ),
+        );
+    }
+
+    /**
+     * List all Tag File Configurations for Doxygen
+     *
+     * @throws AccessDeniedException
+     * @return dictionary {Scope: ACL}, where ACL = dictionnary {user/group: permissions_int}
+     */
+    public function listTagFiles()
+    {
+        /** @var helper_plugin_doxycode_tagmanager $tagmanager */
+        $tagmanager = plugin_load('helper', 'doxycode_tagmanager');
+        
+        $tag_config = $tagmanager->loadTagFileConfig();
+
+        return $tag_config;
+    }
+
+    /**
+     * Add a new entry to ACL config
+     *
+     * @param string $file
+     * @throws AccessDeniedException
+     * @return bool
+     */
+    public function uploadTagFile($filename,$file)
+    {
+        $tagname = pathinfo($filename, PATHINFO_FILENAME);
+
+        /** @var helper_plugin_doxycode_tagmanager $tagmanager */
+        $tagmanager = plugin_load('helper', 'doxycode_tagmanager');
+        
+        $tag_config = $tagmanager->loadTagFileConfig();
+
+        // check file against existing configuration
+        // TODO: check only for configurations that are not remote!
+        if(!in_array($tagname,array_keys($tag_config))) {
+            return array(false);
+        }
+
+        // we have a valid configuration
+
+        // TODO: should we always update the file?
+        // we could also check if the file is updated, so mtime is not update
+        // this way the cache does not get invalidated!
+        $existing_hash = '';
+
+        $existing_file = $tagmanager->getFileName($tagname);
+        if(file_exists($existing_file)) {
+            $existing_content = @file_get_contents($existing_file);
+    
+            $existing_hash = md5($existing_content);
+        }
+        $new_hash = md5($file);
+
+        if($existing_hash !== $new_hash) {
+            // move file into position
+
+            // TODO: we should also check if we have a valid tag file on hand!
+            // possibilities: parse XML, check project name (make setup more complicated!)
+
+            @file_put_contents($existing_file,$file);
+        }
+        
+        return array(true);
+    }
+}


### PR DESCRIPTION
Fixes:
- when creating a new entry, the description value of the new entry had the wrong key and thereby created a unwanted new entry
- in the last commit when adding the RPC call, the remote component was missing
- there was a bug after installing the plugin where the tag file directory was not existent and the plugin failed creating the config because it didn't create the tag file directory