### PR TITLE
Dev/lprobsth enhance

### DIFF
--- a/action.php
+++ b/action.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * DokuWiki Plugin doxycode (Action Component)
  *
@@ -6,51 +7,51 @@
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
 
-if(!defined('DOKU_INC')) die();
-
 use dokuwiki\Extension\ActionPlugin;
 use dokuwiki\HTTP\DokuHTTPClient;
-use dokuwiki\Remote\Api;
 use dokuwiki\Extension\Event;
-use dokuwiki\Cache\Cache; 
+use dokuwiki\Cache\Cache;
+use dokuwiki\Extension\EventHandler;
 
 /**
  * Class action_plugin_doxycode
- * 
+ *
  * This action component of the doxygen plugin handles the download of remote tag files,
  * build job/task execution, cache invalidation, and ajax calls for checking the job/task
  * execution and dynamic loading of finished code snippets.
- * 
+ *
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
-class action_plugin_doxycode extends ActionPlugin {
-
-    public function register(Doku_Event_Handler $controller) {
+class action_plugin_doxycode extends ActionPlugin
+{
+    public function register(EventHandler $controller)
+    {
         $controller->register_hook('INDEXER_TASKS_RUN', 'AFTER', $this, 'loadRemoteTagFiles');
         $controller->register_hook('INDEXER_TASKS_RUN', 'AFTER', $this, 'renderDoxyCodeSnippets');
         $controller->register_hook('PARSER_CACHE_USE', 'BEFORE', $this, 'beforeParserCacheUse');
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'ajaxCall');
         $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insertTagButton');
-        $controller->register_hook('RPC_CALL_ADD','AFTER',$this,'add_rpc_all');
+        $controller->register_hook('RPC_CALL_ADD', 'AFTER', $this, 'addRpcMethod');
     }
     
     /**
      * Download remote doxygen tag files and place the in the tag file directory.
-     * 
+     *
      * Remote tag files are tag files that are publicly hosted on another website.
      * This task runner hook gets the tag file configuration for remote tag files and checks
      * if it is time to check the remote tag file again.
-     * 
+     *
      * If the time threshold is reached for checking again it tries to download the tag file again,
      * updates the 'last_update' timestamp in the configuration, and then checks if we have an updated
      * tag file by comparing the md5 of the cached tag file.
-     * 
+     *
      * The configuration with the updated 'last_update' timestamp is saved without modifying the mtime
      * of the configuration because the configuration file is listed as a file dependency among the used tag files
      * for the cached snippets. We only want to invalidate the cached snippets if the configuration really changes
      * or a new tag file is available.
      */
-    public function loadRemoteTagFiles(Event $event, $param) {
+    public function loadRemoteTagFiles(Event $event, $param)
+    {
         // get the tag files from the helper
 
         /** @var helper_plugin_doxycode_tagmanager $tagmanager */
@@ -63,18 +64,17 @@ class action_plugin_doxycode extends ActionPlugin {
 
         // only try to download a tag file if it is a remote file and enabled!
         // TODO: we could also use a filter function for filtering remote configurations with overdue updates
-        $filtered_config = $tagmanager->filterConfig($tag_config,['isConfigEnabled','isValidRemoteConfig']);
+        $filtered_config = $tagmanager->filterConfig($tag_config, ['isConfigEnabled','isValidRemoteConfig']);
 
         // loop over all tag file configurations
-        foreach($filtered_config as $key => &$conf) {
-
+        foreach ($filtered_config as $key => &$conf) {
             $now = time();
             $timestamp = $conf['last_update'] ? $conf['last_update'] : 0;
             $update_period = $conf['update_period'] ? $conf['update_period'] :  $this->getConf('update_period');
             $filename = $tagmanager->getTagFileDir() . $key . '.xml';
             
             // only try to update every $update_period amount of seconds
-            if($now - $update_period >= $timestamp) {
+            if ($now - $update_period >= $timestamp) {
                 // only process one thing per task runner run
                 $event->stopPropagation();
                 $event->preventDefault();
@@ -84,14 +84,14 @@ class action_plugin_doxycode extends ActionPlugin {
                 // on connection failures, we don't want to run the task runner constantly on failures!
                 // true: do not update the mtime of the configuration!
                 // if a new tag file is available we invalidate the cache if this tag file was used in a page!
-                $tagmanager->saveTagFileConfig($tag_config,true);
+                $tagmanager->saveTagFileConfig($tag_config, true);
 
-                $exists = False;    // if the file does not exist - just write now!
+                $exists = false;    // if the file does not exist - just write now!
                 $cachedHash = '';   // this is used to check if we really have a new file
 
                 // first read the old file and free memory so we do not exeed the limit!
-                if($cachedContent = @file_get_contents($filename)) {
-                    $exists = True;
+                if ($cachedContent = @file_get_contents($filename)) {
+                    $exists = true;
 
                     $cachedHash = md5($cachedContent);
 
@@ -121,7 +121,8 @@ class action_plugin_doxycode extends ActionPlugin {
         }
     }
 
-    public function renderDoxyCodeSnippets(Event $event) {
+    public function renderDoxyCodeSnippets(Event $event)
+    {
         global $ID;
 
         /** @var helper_plugin_doxycode_buildmanager $buildmanager */
@@ -131,20 +132,20 @@ class action_plugin_doxycode extends ActionPlugin {
         // a specific amount of tasks from getBuildTasks
         $tasks = $buildmanager->getBuildTasks();
 
-        if(sizeof($tasks) > 0) {
+        if (sizeof($tasks) > 0) {
             $event->stopPropagation();
             $event->preventDefault();
 
             $iterations = 0;
             // TODO: we should implement a maximum amount of tasks to run in one task runner instance!
-            foreach($tasks as $task) {
+            foreach ($tasks as $task) {
                 $iterations++;
 
-                if($iterations > $this->getConf('runner_max_tasks')) {
+                if ($iterations > $this->getConf('runner_max_tasks')) {
                     return;
                 }
 
-                if(!$buildmanager->runTask($task['TaskID'])) {
+                if (!$buildmanager->runTask($task['TaskID'])) {
                     // if we couldn't build abort the task runner
                     // this might happen if another instance is already running
                     return;
@@ -153,14 +154,15 @@ class action_plugin_doxycode extends ActionPlugin {
         }
     }
 
-    public function beforeParserCacheUse(Event $event) {
+    public function beforeParserCacheUse(Event $event)
+    {
         global $ID;
         $cache = $event->data;
         if (isset($cache->mode) && ($cache->mode == 'xhtml')) {
             // load doxycode meta that includes the used tag files and the cache files for the snippets
             $doxycode_meta = p_get_metadata($ID, 'doxycode');
 
-            if($doxycode_meta == null) {
+            if ($doxycode_meta == null) {
                 // doxycode was not used in this page!
                 return;
             }
@@ -171,7 +173,7 @@ class action_plugin_doxycode extends ActionPlugin {
             // in this case we first need to invalidate the page cache
             $tagfiles = $doxycode_meta['tagfiles'];
 
-            if($tagfiles != null) {
+            if ($tagfiles != null) {
                 // transform the list of tag files into an array that can be used by the helper
                 // ['tag_name' => []]: empty array as value since we do not have a loaded tag configuration here!
                 $tag_config = array_fill_keys($tagfiles, []);
@@ -180,12 +182,13 @@ class action_plugin_doxycode extends ActionPlugin {
                 $helper = plugin_load('helper', 'doxycode');
     
                 // transform the tag names to full file paths
-                $helper->getTagFiles($depends,$tag_config);
+                $helper->getTagFiles($depends, $tag_config);
             };
     
             // load the PHP file dependencies
             // if any file was changed, we want to do a reload
-            // the other dependencies (cache files) might not be enough, if e.g. the way we generate the hash names change
+            // the other dependencies (cache files) might not be enough,
+            // if e.g. the way we generate the hash names change
             // this might happen if the old cache files still exist and the meta data was not updated
             $helper->getPHPFileDependencies($depends);
 
@@ -197,10 +200,10 @@ class action_plugin_doxycode extends ActionPlugin {
             // if the XML cache is not existent we should check if the build is scheduled in the main syntax component
             $cache_files = $doxycode_meta['xml_cachefiles'];
 
-            foreach($cache_files as $cacheID) {
-                $cache_name = getCacheName($cacheID,".xml");
+            foreach ($cache_files as $cacheID) {
+                $cache_name = getCacheName($cacheID, ".xml");
 
-                if(!@file_exists($cache_name)) {
+                if (!@file_exists($cache_name)) {
                     $event->preventDefault();
                     $event->stopPropagation();
                     $event->result = false;
@@ -209,13 +212,14 @@ class action_plugin_doxycode extends ActionPlugin {
                 $this->addDependencies($cache, [$cache_name]);
             }
 
-            // if the HTML cache is not existent we should parse the XML in the main syntax component before the page loads
+            // if the HTML cache is not existent we should parse
+            // the XML in the main syntax component before the page loads
             $cache_files = $doxycode_meta['html_cachefiles'];
 
-            foreach($cache_files as $cacheID) {
-                $cache_name = getCacheName($cacheID,".html");
+            foreach ($cache_files as $cacheID) {
+                $cache_name = getCacheName($cacheID, ".html");
 
-                if(!@file_exists($cache_name)) {
+                if (!@file_exists($cache_name)) {
                     $event->preventDefault();
                     $event->stopPropagation();
                     $event->result = false;
@@ -229,7 +233,7 @@ class action_plugin_doxycode extends ActionPlugin {
 
     /**
      * Add extra dependencies to the cache
-     * 
+     *
      * copied from changes plugin
      */
     protected function addDependencies($cache, $depends)
@@ -253,8 +257,9 @@ class action_plugin_doxycode extends ActionPlugin {
     /**
      * handle ajax requests
      */
-    public function ajaxCall(Event $event) {
-        switch($event->data) {
+    public function ajaxCall(Event $event)
+    {
+        switch ($event->data) {
             case 'plugin_doxycode_check_status':
             case 'plugin_doxycode_get_snippet_html':
             case 'plugin_doxycode_get_tag_files':
@@ -267,7 +272,7 @@ class action_plugin_doxycode extends ActionPlugin {
         $event->stopPropagation();
         $event->preventDefault();
 
-        if($event->data === 'plugin_doxycode_check_status') {
+        if ($event->data === 'plugin_doxycode_check_status') {
             // the main syntax component has put placeholders into the page while rendering
             // the client tries to get the newest state for the doxygen builds executed through the buildmanager
 
@@ -279,8 +284,8 @@ class action_plugin_doxycode extends ActionPlugin {
             $hashes = $INPUT->arr('hashes');
     
             // get the job state for each XML file
-            foreach($hashes as &$hash) {
-                if(strlen($hash['xmlHash']) > 0) {
+            foreach ($hashes as &$hash) {
+                if (strlen($hash['xmlHash']) > 0) {
                     $hash['state'] = $buildmanager->getJobState($hash['xmlHash']);
                 }
             }
@@ -292,7 +297,7 @@ class action_plugin_doxycode extends ActionPlugin {
             return;
         } // plugin_doxycode_check_status
 
-        if($event->data === 'plugin_doxycode_get_snippet_html') {
+        if ($event->data === 'plugin_doxycode_get_snippet_html') {
             header('Content-Type: application/json');
             
             // a client tries to dynamically load the rendered code snippet
@@ -319,7 +324,7 @@ class action_plugin_doxycode extends ActionPlugin {
             $tag_conf = $tagmanager->getFilteredTagConfig($task_config['tagfiles']);
 
             $depends = [];
-            $helper->getHTMLFileDependencies($depends,$html_cacheID,$tag_conf);
+            $helper->getHTMLFileDependencies($depends, $html_cacheID, $tag_conf);
 
             $data = [
                 'success' => false,
@@ -328,10 +333,10 @@ class action_plugin_doxycode extends ActionPlugin {
             ];
 
             // how will we generate the dependencies?
-            if($html_cache->useCache($depends)) {
+            if ($html_cache->useCache($depends)) {
                 // we have a valid HTML rendered!
 
-                if($cachedContent = @file_get_contents($html_cache->cache)) {
+                if ($cachedContent = @file_get_contents($html_cache->cache)) {
                     // add HTML cache to response
 
                     $data['html'] = $cachedContent;
@@ -345,18 +350,18 @@ class action_plugin_doxycode extends ActionPlugin {
             $job_config = $buildmanager->getJobConf($xml_cacheID);
 
             $depends = [];
-            $helper->getXMLFileDependencies($depends,$tag_conf);
+            $helper->getXMLFileDependencies($depends, $tag_conf);
             //set content type
 
-            if($xml_cache->useCache($depends)) {
+            if ($xml_cache->useCache($depends)) {
                 // we have a valid XML!
 
                 $xml_content = @file_get_contents($xml_cache->cache);
 
-                $rendered_text = $parser->renderXMLToDokuWikiCode($xml_content,$job_config['linenumbers'],$tag_conf);
+                $rendered_text = $parser->renderXMLToDokuWikiCode($xml_content, $job_config['linenumbers'], $tag_conf);
                 
                 // save content to cache
-                @file_put_contents($html_cache->cache,$rendered_text);
+                @file_put_contents($html_cache->cache, $rendered_text);
 
                 // add HTML to response
                 $data['html'] = $rendered_text;
@@ -371,7 +376,7 @@ class action_plugin_doxycode extends ActionPlugin {
             return;
         } // plugin_doxycode_get_snippet_html
 
-        if($event->data === 'plugin_doxycode_get_tag_files') {
+        if ($event->data === 'plugin_doxycode_get_tag_files') {
             // the client has requested a list of available tag file configurations
 
             /** @var helper_plugin_doxycode_tagmanager $tagmanager */
@@ -389,24 +394,24 @@ class action_plugin_doxycode extends ActionPlugin {
         }
     }
 
-    public function insertTagButton(Event $event) {
+    public function insertTagButton(Event $event)
+    {
         $event->data[] = array (
             'type' => 'doxycodeTagSelector',
             'title' => 'doxycode',
-            'icon' => DOKU_REL.'lib/plugins/doxycode/images/toolbar/doxycode.png',
+            'icon' => DOKU_REL . 'lib/plugins/doxycode/images/toolbar/doxycode.png',
             'open'   => '<doxycode>',
             'close'  => '</doxycode>',
             'block'  => false
         );
     }
 
-    public function add_rpc_all(&$event, $param){
-        $my_rpc_call=array(
+    public function addRpcMethod(&$event, $param)
+    {
+        $my_rpc_call = array(
             'doxycode.listTagFiles' => array('doxycode', 'listTagFiles'),
-            'doxycode.uploadTagFile'=>array('doxycode', 'uploadTagFile')
+            'doxycode.uploadTagFile' => array('doxycode', 'uploadTagFile')
         );
-        $event->data=array_merge($event->data,$my_rpc_call);
+        $event->data = array_merge($event->data, $my_rpc_call);
     }
 }
-
-?>

--- a/action.php
+++ b/action.php
@@ -324,7 +324,7 @@ class action_plugin_doxycode extends ActionPlugin
             $tag_conf = $tagmanager->getFilteredTagConfig($task_config['tagfiles']);
 
             $depends = [];
-            $helper->getHTMLFileDependencies($depends, $html_cacheID, $tag_conf);
+            $helper->getHTMLFileDependencies($depends, $xml_cacheID, $tag_conf);
 
             $data = [
                 'success' => false,

--- a/admin.php
+++ b/admin.php
@@ -1,7 +1,8 @@
 <?php
+
 /**
  * DokuWiki Plugin doxycode (Admin Component)
- * 
+ *
  * @license     GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
@@ -11,24 +12,24 @@ use dokuwiki\Form\Form;
 
 /**
  * Class admin_plugin_doxycode
- * 
+ *
  * This admin plugin implements the management of tag files from differen doxygen
  * documentations for building cross referenced code snippets.
- * 
+ *
  * It lists all currently configured tag files and all tag files present in the file system
  * of the plugin. The user can add new tag file configurations via upload or by defining a new configuration.
- * 
+ *
  * The admin interface uses the helper_plugin_doxycode_tagmanager helper plugin for loading the current tag file
  * list. On save it also uses the helper for storing the configuration in a json file.
- * 
+ *
  * On save and update it also checks if a configuration is valid and can stay enabled.
- * 
+ *
  * If a new remote config was defined, the action component of this plugin tries to download the tag file.
- * 
+ *
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
-class admin_plugin_doxycode extends AdminPlugin {
- 
+class admin_plugin_doxycode extends AdminPlugin
+{
     /** @var helper_plugin_doxycode_tagmanager $helper */
     private $helper;
     private $tag_config;
@@ -42,7 +43,8 @@ class admin_plugin_doxycode extends AdminPlugin {
         'description' => 40
     );
 
-    function __construct() {
+    public function __construct()
+    {
         $this->helper = plugin_load('helper', 'doxycode_tagmanager');
 
         // load files
@@ -59,7 +61,8 @@ class admin_plugin_doxycode extends AdminPlugin {
     /**
      * handle user request
      */
-    public function handle() {
+    public function handle()
+    {
         global $INPUT;
         global $_FILES;
  
@@ -72,22 +75,24 @@ class admin_plugin_doxycode extends AdminPlugin {
 
         $new_tag_config = $INPUT->arr('tag_config');
 
-        // handle upload command	
+        // handle upload command
         // if a new file was added, we move the file to the tagfile directory
         // and add the file to the tagfile configuration for rendering
         // on the next load of the page the tag file will be loaded to configuration
         // from the tag file list from the directory
-        if($cmd['update'] && isset($_FILES['upload']) && $_FILES['upload']['error'] != UPLOAD_ERR_NO_FILE) {
-            if ($_FILES['upload']['error'] == 0){
-                if ('xml' != pathinfo($_FILES['upload']['name'], PATHINFO_EXTENSION)){
-                    msg(sprintf($this->getLang('admin_err_no_xml_file'),$_FILES['upload']['name']), 2);
-                }else {
+        if ($cmd['update'] && isset($_FILES['upload']) && $_FILES['upload']['error'] != UPLOAD_ERR_NO_FILE) {
+            if ($_FILES['upload']['error'] == 0) {
+                if ('xml' != pathinfo($_FILES['upload']['name'], PATHINFO_EXTENSION)) {
+                    msg(sprintf($this->getLang('admin_err_no_xml_file'), $_FILES['upload']['name']), 2);
+                } else {
                     // if tag file directory does not exist, create it!
                     $this->helper->createTagFileDir();
 
-                    move_uploaded_file($_FILES['upload']['tmp_name'],
-                        DOKU_PLUGIN.'doxycode/tagfiles/'.$_FILES['upload']['name']);
-                    msg(sprintf($this->getLang('admin_info_upload_success'),$_FILES['upload']['name']), 1);
+                    move_uploaded_file(
+                        $_FILES['upload']['tmp_name'],
+                        DOKU_PLUGIN . 'doxycode/tagfiles/' . $_FILES['upload']['name']
+                    );
+                    msg(sprintf($this->getLang('admin_info_upload_success'), $_FILES['upload']['name']), 1);
                     $this->tag_config[pathinfo($_FILES['upload']['name'], PATHINFO_FILENAME)] = [];
                 }
             } else {
@@ -96,9 +101,12 @@ class admin_plugin_doxycode extends AdminPlugin {
         }
 
         // add new element from form
-        if(isset($new_tag_config['new'])) {
+        if (isset($new_tag_config['new'])) {
             // do we have a valid new entry && is this entry name not already set?
-            if(strlen($new_tag_config['new']['new_name']) > 0 && !isset($this->tag_config[$new_tag_config['new']['new_name']])) {
+            if (
+                strlen($new_tag_config['new']['new_name']) > 0
+                && !isset($this->tag_config[$new_tag_config['new']['new_name']])
+            ) {
                 $newKey = $new_tag_config['new']['new_name'];
 
                 // unset the temporary new name that otherwise would mean a rename/move
@@ -106,32 +114,32 @@ class admin_plugin_doxycode extends AdminPlugin {
 
                 // add new tag_config element to global config
                 $this->tag_config[$newKey] = $new_tag_config['new'];
-                msg(sprintf($this->getLang('admin_info_new_tag_config'),$newKey), 1);
+                msg(sprintf($this->getLang('admin_info_new_tag_config'), $newKey), 1);
             }
             unset($new_tag_config['new']); // Remove the 'new' placeholder
         }
 
         // update our configuration from the input data
-        if($cmd['save'] || $cmd['update']) {
-            foreach($new_tag_config as $key => $tag_conf) {
+        if ($cmd['save'] || $cmd['update']) {
+            foreach ($new_tag_config as $key => $tag_conf) {
                 $this->tag_config[$key] = $tag_conf;
             }
         }
 
         // check if settings are valid for the enabled state
         // TODO: implement tagmanager functions for checking if a config can be enabled!
-        if($cmd['save'] || $cmd['update']) {
-            foreach($this->tag_config as $key => &$tag_conf) {
+        if ($cmd['save'] || $cmd['update']) {
+            foreach ($this->tag_config as $key => &$tag_conf) {
                 // if element is disable continue
-                if(!isset($tag_conf['enabled']) || !$tag_conf['enabled']) continue;
+                if (!isset($tag_conf['enabled']) || !$tag_conf['enabled']) continue;
 
                 // if docu_url is missing
-                if(strlen($tag_conf['docu_url']) <= 0) {
+                if (strlen($tag_conf['docu_url']) <= 0) {
                     $tag_conf['enabled'] = false;
                     continue;
                 }
 
-                if(strlen($tag_conf['remote_url']) > 0 && strlen($tag_conf['update_period']) <= 0) {
+                if (strlen($tag_conf['remote_url']) > 0 && strlen($tag_conf['update_period']) <= 0) {
                     $tag_conf['enabled'] = false;
                     continue;
                 }
@@ -141,24 +149,27 @@ class admin_plugin_doxycode extends AdminPlugin {
             unset($tag_conf);
         }
 
-        if($cmd['save']) {
+        if ($cmd['save']) {
             // delete entries that are marked for deletion
-            foreach($this->tag_config as $key => $tag_conf) {
-                if(isset($tag_conf['delete']) && $tag_conf['delete']) {
+            foreach ($this->tag_config as $key => $tag_conf) {
+                if (isset($tag_conf['delete']) && $tag_conf['delete']) {
                     unset($this->tag_config[$key]);
 
                     // delete the tag file if it exists!
                     $filename = $this->helper->getTagFileDir() . $key . '.xml';
-                    if(file_exists($filename)) {
+                    if (file_exists($filename)) {
                         unlink($filename);
-                        msg(sprintf($this->getLang('admin_info_tag_deleted'),pathinfo($filename, PATHINFO_BASENAME)), 1);
+                        msg(sprintf(
+                            $this->getLang('admin_info_tag_deleted'),
+                            pathinfo($filename, PATHINFO_BASENAME)
+                        ), 1);
                     }
                 }
             }
 
             // handle renames
-            foreach($this->tag_config as $key => $tag_conf) {
-                if(isset($tag_conf['new_name']) && $key !== $tag_conf['new_name']) {
+            foreach ($this->tag_config as $key => $tag_conf) {
+                if (isset($tag_conf['new_name']) && $key !== $tag_conf['new_name']) {
                     // TODO: check if an entry with this newName already exists!
                     // if it already exists we can't rename it -> show msg to user!
                     $newName = $tag_conf['new_name'];
@@ -166,11 +177,13 @@ class admin_plugin_doxycode extends AdminPlugin {
                     $this->tag_config[$newName] = $tag_conf;
                     unset($this->tag_config[$newName]['new_name']);
 
-                    rename( $this->helper->getTagFileDir() . $key . 'xml', $this->helper->getTagFileDir() . $newName . '.xml');
+                    rename($this->helper->getTagFileDir()
+                        . $key . 'xml', $this->helper->getTagFileDir() . $newName . '.xml');
 
                     // TODO: rename tag in page!
                     // I looked into the move plugin
-                    // it might be possible to handle renaming if the move plugin supports custom types (currently only media and pages)
+                    // it might be possible to handle renaming
+                    // if the move plugin supports custom types (currently only media and pages)
 
                     // TODO: notify user through msg that the tag file was renamed!
                 }
@@ -183,7 +196,8 @@ class admin_plugin_doxycode extends AdminPlugin {
     /**
      * output appropriate html
      */
-    public function html() {
+    public function html()
+    {
         global $ID;#
         global $conf;
         global $lang;
@@ -194,7 +208,7 @@ class admin_plugin_doxycode extends AdminPlugin {
         $form = new Form(['enctype' => 'multipart/form-data']);
 
         // new file
-        $form->addElement(new dokuwiki\Form\InputElement('file','upload',$this->getLang('admin_upload')));
+        $form->addElement(new dokuwiki\Form\InputElement('file', 'upload', $this->getLang('admin_upload')));
 
         $form->addHTML('<br>');
         $form->addHTML('<br>');
@@ -225,25 +239,25 @@ class admin_plugin_doxycode extends AdminPlugin {
         // add body
         $form->addTagOpen('tbody');
 
-        foreach($this->tag_config as $key => $tag_conf) {
+        foreach ($this->tag_config as $key => $tag_conf) {
             $form->addTagOpen('tr');
 
             $form->addTagOpen('td');
             $checkbox = $form->addCheckbox('tag_config[' . $key . '][delete]')
                 ->useInput(false);
-                if($tag_conf['delete']) $checkbox->attrs(['checked' => 'checked']);
+                if ($tag_conf['delete']) $checkbox->attrs(['checked' => 'checked']);
             $form->addTagClose('td');
 
             $form->addTagOpen('td');
             $checkbox = $form->addCheckbox('tag_config[' . $key . '][enabled]')
                 ->useInput(false);
-            if($tag_conf['enabled']) $checkbox->attrs(['checked' => 'checked']);
+            if ($tag_conf['enabled']) $checkbox->attrs(['checked' => 'checked']);
             $form->addTagClose('td');
 
             $form->addTagOpen('td');
             $checkbox = $form->addCheckbox('tag_config[' . $key . '][force_runner]')
                 ->useInput(false);
-            if($tag_conf['force_runner']) $checkbox->attrs(['checked' => 'checked']);
+            if ($tag_conf['force_runner']) $checkbox->attrs(['checked' => 'checked']);
             $form->addTagClose('td');
 
             $form->addTagOpen('td');
@@ -252,13 +266,13 @@ class admin_plugin_doxycode extends AdminPlugin {
                 ->useInput(false);
 
             // add red highlight if this file does not exist
-            if(file_exists($this->helper->getFileName($key))) {
+            if (file_exists($this->helper->getFileName($key))) {
                 $new_name->attrs(['style' => 'background-color: LightGreen']);
             } else {
                 $new_name->attrs(['style' => 'background-color: LightCoral']);
             }
 
-            if(isset($tag_conf['new_name'])) {
+            if (isset($tag_conf['new_name'])) {
                 $new_name->val($tag_conf['new_name']);
             } else {
                 $new_name->val($key);
@@ -267,7 +281,7 @@ class admin_plugin_doxycode extends AdminPlugin {
 
             // print file mtime for better understanding of update mechanism by admin
             $form->addTagOpen('td');
-            if(file_exists($this->helper->getFileName($key))) {
+            if (file_exists($this->helper->getFileName($key))) {
                 $form->addLabel(dformat(@filemtime($this->helper->getFileName($key))));
             }
             $form->addTagClose('td');
@@ -292,11 +306,11 @@ class admin_plugin_doxycode extends AdminPlugin {
                 ->useInput(false)
                 ->val($tag_conf['update_period']);
 
-            if($tag_conf['update_period'] > 0) {
+            if ($tag_conf['update_period'] > 0) {
                 $timestamp = $conf['last_update'] ? $conf['last_update'] : 0;
                 $now = time();
 
-                if($now - $tag_conf['update_period'] >= $timestamp) {
+                if ($now - $tag_conf['update_period'] >= $timestamp) {
                     $period->attrs(['style' => 'background-color: LightGreen']);
                 } else {
                     $period->attrs(['style' => 'background-color: LightCoral']);
@@ -379,8 +393,8 @@ class admin_plugin_doxycode extends AdminPlugin {
         $form->addTagClose('table');
         $form->addTagClose('div');
 
-        $form->addButton('cmd[save]',$lang['btn_save'])->attrs(['accesskey' => 's']);
-        $form->addButton('cmd[update]',$lang['btn_update']);
+        $form->addButton('cmd[save]', $lang['btn_save'])->attrs(['accesskey' => 's']);
+        $form->addButton('cmd[update]', $lang['btn_update']);
 
         echo $form->toHTML();
 
@@ -393,8 +407,8 @@ class admin_plugin_doxycode extends AdminPlugin {
      *
      * @return bool
      */
-    public function forAdminOnly() {
+    public function forAdminOnly()
+    {
         return false;
     }
- 
 }

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * default configuration settings
  *

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * configuration metadata
  *

--- a/helper.php
+++ b/helper.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * DokuWiki Plugin doxycode (Helper Component)
  *
@@ -6,49 +7,48 @@
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
 
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
-
-use \dokuwiki\Extension\Plugin;
+use dokuwiki\Extension\Plugin;
 
 /**
  * Class helper_plugin_doxycode
- * 
+ *
  * This helper plugin implements some common functions for the doxygen plugin.
  * Its main use is the creation of the file dependencies of XML and HTML cache files
  * for cache validation in the other components.
- * 
+ *
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
-class helper_plugin_doxycode extends Plugin {
-
+class helper_plugin_doxycode extends Plugin
+{
     /** @var helper_plugin_doxycode_tagmanager $tagmanager */
     protected $tagmanager;
 
-    function __construct()
+    public function __construct()
     {
         $this->tagmanager = plugin_load('helper', 'doxycode_tagmanager');
     }
 
 
-    public function getXMLFileDependencies(&$dependencies,$tag_conf = null) {
+    public function getXMLFileDependencies(&$dependencies, $tag_conf = null)
+    {
 
-        $this->getTagFiles($dependencies,$tag_conf);
+        $this->getTagFiles($dependencies, $tag_conf);
 
         // add the configuration file
-        $this->_addDefaultDependencies($dependencies);
+        $this->addDefaultDependencies($dependencies);
 
         return $dependencies;
     }
 
-    public function getHTMLFileDependencies(&$dependencies,$xml_cacheID,$tag_conf = null) {
+    public function getHTMLFileDependencies(&$dependencies, $xml_cacheID, $tag_conf = null)
+    {
 
-        $this->getTagFiles($dependencies,$tag_conf);
+        $this->getTagFiles($dependencies, $tag_conf);
 
         // add the configuration file
-        $this->_addDefaultDependencies($dependencies);
+        $this->addDefaultDependencies($dependencies);
 
-        $xml_cache = getCacheName($xml_cacheID,'.xml');
+        $xml_cache = getCacheName($xml_cacheID, '.xml');
 
         // add the configuration file
         $dependencies['files'][] = DOKU_PLUGIN . $this->getPluginName() . '/helper/parser.php';
@@ -57,16 +57,18 @@ class helper_plugin_doxycode extends Plugin {
         return $dependencies;
     }
 
-    public function getTagFiles(&$dependencies,$tag_conf = null) {
+    public function getTagFiles(&$dependencies, $tag_conf = null)
+    {
         // generate the full filepaths for the $tag_conf entries
 
-        foreach($tag_conf as $key => $conf) {
+        foreach ($tag_conf as $key => $conf) {
             // TODO: should we check if the file exists?
             $dependencies['files'][] = $this->tagmanager->getTagFileDir() . $key . '.xml';
         }
     }
 
-    protected function _addDefaultDependencies(&$dependencies) {
+    protected function addDefaultDependencies(&$dependencies)
+    {
         $dependencies['files'][] = $this->tagmanager->getTagFileDir() . 'tagconfig.json';
         // add the doxygen configuration template
         $dependencies['files'][] = DOKU_PLUGIN . $this->getPluginName()  . '/doxygen.conf';
@@ -79,15 +81,25 @@ class helper_plugin_doxycode extends Plugin {
         $dependencies['files'][] = DOKU_PLUGIN . $this->getPluginName() . '/helper.php';
     }
 
-    public function getPHPFileDependencies(&$dependencies) {
+    public function getPHPFileDependencies(&$dependencies)
+    {
 
         $dependencies['files'][] = $this->tagmanager->getTagFileDir() . 'tagconfig.json';
         // add the doxygen configuration template
         $dependencies['files'][] = DOKU_PLUGIN . $this->getPluginName()  . '/doxygen.conf';
 
         // easy cache invalidation on code change
-        $dependencies['files'] = array_merge($dependencies['files'],glob( DOKU_PLUGIN . $this->getPluginName() . '/*.php'));
-        $dependencies['files'] = array_merge($dependencies['files'],glob( DOKU_PLUGIN . $this->getPluginName() . '/syntax/*.php'));
-        $dependencies['files'] = array_merge($dependencies['files'],glob( DOKU_PLUGIN . $this->getPluginName() . '/helper/*.php'));
+        $dependencies['files'] = array_merge(
+            $dependencies['files'],
+            glob(DOKU_PLUGIN . $this->getPluginName() . '/*.php')
+        );
+        $dependencies['files'] = array_merge(
+            $dependencies['files'],
+            glob(DOKU_PLUGIN . $this->getPluginName() . '/syntax/*.php')
+        );
+        $dependencies['files'] = array_merge(
+            $dependencies['files'],
+            glob(DOKU_PLUGIN . $this->getPluginName() . '/helper/*.php')
+        );
     }
 }

--- a/helper/buildmanager.php
+++ b/helper/buildmanager.php
@@ -2,55 +2,52 @@
 
 /**
  * DokuWiki Plugin doxycode (Buildmanager Helper Component)
- * 
+ *
  * @license     GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
 
-
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
-
-use \dokuwiki\Extension\Plugin;
+use dokuwiki\Extension\Plugin;
 use dokuwiki\plugin\sqlite\SQLiteDB;
 use dokuwiki\ErrorHandler;
 
 /**
  * Class helper_plugin_doxycode_buildmanager
- * 
+ *
  * This class manages the build of code snippets with doxygen for cross referencing.
- * 
+ *
  * Job: A build job is a single code snippet.
  * JobID: md5 of doxygen config + code.
  * Task: A build task has one or multiple build jobs.
  * TaskID: md5 of doxygen config.
- * 
+ *
  * The build is executed in build tasks that are either directly executed or scheduled with
  * the help of the sqlite plugin. If the sqlite plugin is not available, the scheduling fails.
  * Since the task is then not scheduled and no cache file is available, the snippet syntax
  * should then try to build the code snippet again.
- * 
+ *
  * Depending on the used tag files for doxygen, each build can both take long and be ressource
  * hungry. It therefore is only allowed to have one doxygen instance running at all times. This
  * is enforced with a lock that indicates if doxygen is running or not. In case of immediate build
  * tasks through tryBuildNow() the buildmanager will then try to schedule the build task.
- * 
+ *
  * If a build with the same TaskID is already running, a new TaskID will be randomly created.
  * This way we ensure that we don't mess with an already running task.
- * 
+ *
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
-class helper_plugin_doxycode_buildmanager extends Plugin {
-    const STATE_NON_EXISTENT = 1;
-    const STATE_RUNNING = 2;
-    const STATE_SCHEDULED = 3;
-    const STATE_FINISHED = 4;
-    const STATE_ERROR = 5;
+class helper_plugin_doxycode_buildmanager extends Plugin
+{
+    public const STATE_NON_EXISTENT = 1;
+    public const STATE_RUNNING = 2;
+    public const STATE_SCHEDULED = 3;
+    public const STATE_FINISHED = 4;
+    public const STATE_ERROR = 5;
 
     /**
      * @var string Filename of the lock file for only allowing one doxygen process.
      */
-    const LOCKFILENAME = '_plugin_doxycode.lock';
+    protected const LOCKFILENAME = '_plugin_doxycode.lock';
 
     protected $db = null;
 
@@ -71,10 +68,10 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
         'render_task'
     );
 
-    function __construct()
+    public function __construct()
     {
         // check if sqlite is available
-        if(!plugin_isdisabled('sqlite')) {
+        if (!plugin_isdisabled('sqlite')) {
             if ($this->db === null) {
                 try {
                     $this->db = new SQLiteDB('doxycode', DOKU_PLUGIN . 'doxycode/db/');
@@ -89,42 +86,50 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Add a build job to the task runner builder and create or update a build task if necessary.
-     * 
+     *
      * This function adds a new build job to the Jobs table in sqlite.
      * Each build job corresponds to a build task. If no build task exists for the build job it will create a new one
      * and insert it to the Tasks table in sqlite.
-     * 
-     * If the build task for this build job is existing it will try to change its state to 'STATE_SCHEDULED' to run it again.
+     *
+     * If the build task for this build job is existing it will try to
+     * change its state to 'STATE_SCHEDULED' to run it again.
      * If the build task is already running, we don't want to interfere the doxygen build process. In that case
      * we create a new build task for this build job with a random taskID.
-     * 
+     *
      * @param String $jobID Identifier for this build job
      * @param Array &$config Arguments from the snippet syntax containing the configuration for the snippet
      * @param String $content Code snippet content
      * @return Bool If adding the build job was successful
      */
-    public function addBuildJob($jobID,&$config,$content) {
-        if($this->db === null) {
+    public function addBuildJob($jobID, &$config, $content)
+    {
+        if ($this->db === null) {
             return false;
         }
 
-        // TODO: is a race condition possible where we add a job to a task and during that operation the task runner start executing the task?
+        // TODO: is a race condition possible where we add a job to a
+        // task and during that operation the task runner start executing the task?
 
         // check if the Task is already running
         $row = $this->db->queryRecord('SELECT * FROM Tasks WHERE TaskID = ?', [$config['taskID']]);
 
-        switch($row['State']) {
+        switch ($row['State']) {
             case self::STATE_ERROR: // fall through
             case self::STATE_FINISHED: {
                 // this means that the build directory probably was already deleted
                 // we can just recreate the directory or put our job into the existing build directory
-                $id = $this->db->exec('UPDATE Tasks SET Timestamp = CURRENT_TIMESTAMP, State = ? WHERE TaskID = ?',
-                    [self::STATE_SCHEDULED, $config['taskID']]);
+                $id = $this->db->exec(
+                    'UPDATE Tasks SET Timestamp = CURRENT_TIMESTAMP, State = ? WHERE TaskID = ?',
+                    [self::STATE_SCHEDULED, $config['taskID']]
+                );
                 break;
             }
             case self::STATE_SCHEDULED: {
                 // just update the timestamp so we don't accidentally delete this task
-                $id = $this->db->exec('UPDATE Tasks SET Timestamp = CURRENT_TIMESTAMP WHERE TaskID = ?', [$config['taskID']]);
+                $id = $this->db->exec(
+                    'UPDATE Tasks SET Timestamp = CURRENT_TIMESTAMP WHERE TaskID = ?',
+                    [$config['taskID']]
+                );
                 break;
             }
             case self::STATE_RUNNING: {
@@ -134,16 +139,25 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
             case null;
             case '': {
                 // we need to create a new task!
-                $id = $this->db->exec('INSERT INTO Tasks (TaskID, State, Timestamp, Configuration) VALUES (?, ?, CURRENT_TIMESTAMP, ?)',
-                    [$config['taskID'], self::STATE_SCHEDULED, json_encode($this->filterDoxygenAttributes($config,false),true)]);
+                $id = $this->db->exec(
+                    'INSERT INTO Tasks (TaskID, State, Timestamp, Configuration) VALUES (?, ?, CURRENT_TIMESTAMP, ?)',
+                    [
+                        $config['taskID'],
+                        self::STATE_SCHEDULED,
+                        json_encode(
+                            $this->filterDoxygenAttributes($config, false),
+                            true
+                        )
+                    ]
+                );
                 break;
             }
         }
 
         // create the job file with the code snippet content
-        $tmp_dir = $this->_createJobFile($jobID,$config,$content);
+        $tmp_dir = $this->createJobFile($jobID, $config, $content);
 
-        if(strlen($tmp_dir) == 0) {
+        if (strlen($tmp_dir) == 0) {
             return false;
         }
         
@@ -152,7 +166,7 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
         $data = [
             'JobID' => $jobID,
             'TaskID' => $config['taskID'],
-            'Configuration' => json_encode($this->filterDoxygenAttributes($config,true),true)
+            'Configuration' => json_encode($this->filterDoxygenAttributes($config, true), true)
         ];
 
         $new = $this->db->saveRecord('Jobs', $data);
@@ -162,25 +176,26 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Try to immediately build a code snippet.
-     * 
+     *
      * If a lock for the doxygen process is present doxygen is already running.
      * In that case we try to add the build job to the build queue (if sqlite is available).
-     * 
+     *
      * @param String $jobID Identifier for this build job
      * @param Array &$config Arguments from the snippet syntax containing the configuration for the snippet
      * @param String $content Code snippet content
      * @param Array $tag_conf Tag file configuration used for passing the tag files to doxygen
      * @return Bool If build or adding it to the build queue as a build job was successful
      */
-    public function tryBuildNow($jobID,&$config,$content,$tag_conf) {
+    public function tryBuildNow($jobID, &$config, $content, $tag_conf)
+    {
         global $conf;
 
         // first try to detect if a doxygen instance is already running
-        if(!$this->_lock()) {
+        if (!$this->lock()) {
             // we cannot build now because only one doxygen instance is allowed at a time!
             // this will return false if task runner is not available
             // otherwise it will create a task and a job
-            return $this->addBuildJob($jobID,$conf,$content);
+            return $this->addBuildJob($jobID, $conf, $content);
             
             $config['render_task'] = true;
         }
@@ -190,45 +205,46 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
         // TODO: should we also create entries for Task and Job in sqlite if we directly build the snippet?
 
         // create the directory where rendering with doxygen takes place
-        $tmp_dir = $this->_createJobFile($jobID,$config,$content);
+        $tmp_dir = $this->createJobFile($jobID, $config, $content);
 
-        if(strlen($tmp_dir) == 0) {
-            $this->_unlock();
+        if (strlen($tmp_dir) == 0) {
+            $this->unlock();
 
             return false;
         }
 
         // run doxygen on our file with XML output
-        $this->_runDoxygen($tmp_dir, $tag_conf);
+        $this->runDoxygen($tmp_dir, $tag_conf);
 
         // delete tmp_dir
-        if(!$conf['allowdebug']) {
-            $this->_deleteTaskDir($tmp_dir);
+        if (!$conf['allowdebug']) {
+            $this->deleteTaskDir($tmp_dir);
         }
 
 
-        $this->_unlock();
+        $this->unlock();
 
         return true;
     }
 
     /**
      * Get the state of a build task from the Tasks table in sqlite.
-     * 
+     *
      * If no entry for this task could be found in sqlite we return STATE_NON_EXISTENT.
-     * 
+     *
      * @param String $id TaskID of the build task
      * @return Num Task State
      */
-    public function getTaskState($id) {
-        if($this->db === null) {
+    public function getTaskState($id)
+    {
+        if ($this->db === null) {
             // TODO: better return value?
             return self::STATE_NON_EXISTENT;
         }
 
         $row = $this->db->queryRecord('SELECT * FROM Tasks WHERE TaskID = ?', $id);
 
-        if($row !== null) {
+        if ($row !== null) {
             return $row['State'];
         } else {
             return self::STATE_NON_EXISTENT;
@@ -237,15 +253,16 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Get the state of a build job.
-     * 
+     *
      * Here we first lookup the corresponding build task for the build job and then lookup
      * the task state with getTaskState.
-     * 
+     *
      * @param String $jobID JobID for this build job
      * @return Num Job State
      */
-    public function getJobState($jobID) {
-        if($this->db === null) {
+    public function getJobState($jobID)
+    {
+        if ($this->db === null) {
             // TODO: better return value?
             return self::STATE_NON_EXISTENT;
         }
@@ -254,7 +271,7 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
         $row = $this->db->queryRecord('SELECT * FROM Jobs WHERE JobID = ?', $jobID);
 
         // check the task state and return as job state
-        if($row !== null) {
+        if ($row !== null) {
             // TODO: can we directly retreive the Task from our reference in sqlite?
             return $this->getTaskState($row['TaskID']);
         } else {
@@ -264,25 +281,26 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Return the doxygen relevant build task configuration of a build task.
-     * 
+     *
      * This is useful in a context where the configuration can not be obtained from the snippet syntax.
-     * 
+     *
      * An example for this is the 'plugin_doxycode_get_snippet_html' ajax call where the doxygen output XML is parsed.
      * There we need the configuration for matching the used tag files.
-     * 
+     *
      * @param String $taskID TaskID for this build task
      * @return Array Task configuration including the used tag files
      */
-    public function getTaskConf($taskID) {
-        if($this->db === null) {
+    public function getTaskConf($taskID)
+    {
+        if ($this->db === null) {
             // TODO: better return value?
             return [];
         }
 
         $row = $this->db->queryRecord('SELECT Configuration FROM Tasks WHERE TaskID = ?', $taskID);
 
-        if($row !== null) {
-            return json_decode($row['Configuration'],true);
+        if ($row !== null) {
+            return json_decode($row['Configuration'], true);
         } else {
             return [];
         }
@@ -290,17 +308,18 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Return the doxygen relevant build task configuration configuration of a build job.
-     * 
+     *
      * This is useful in a context where the configuration can not be obtained from the snippet syntax.
-     * 
+     *
      * We first obtain the corresponding TaskID from the Jobs table in sqlite.
      * We then call getTaskConf to get the task configuration.
-     * 
+     *
      * @param String $jobID JobID for this Job
      * @return Array Task configuration including the used tag files
      */
-    public function getJobTaskConf($jobID) {
-        if($this->db === null) {
+    public function getJobTaskConf($jobID)
+    {
+        if ($this->db === null) {
             // TODO: better return value?
             return [];
         }
@@ -309,7 +328,7 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
         $row = $this->db->queryRecord('SELECT * FROM Jobs WHERE JobID = ?', $jobID);
 
         // get the Configuration from the Task
-        if($row !== null) {
+        if ($row !== null) {
             return $this->getTaskConf($row['TaskID']);
         } else {
             return [];
@@ -318,14 +337,15 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Get the HTML relevant configuration of a build job.
-     * 
+     *
      * This is useful in a context where the configuration can not be obtained from the snippet syntax.
-     * 
+     *
      * @param String $jobID JobID for this Job
      * @return Array Task configuration including linenumbers, filename, etc.
      */
-    public function getJobConf($jobID) {
-        if($this->db === null) {
+    public function getJobConf($jobID)
+    {
+        if ($this->db === null) {
             // TODO: better return value?
             return [];
         }
@@ -333,8 +353,8 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
         // get the TaskID from sqlite
         $row = $this->db->queryRecord('SELECT Configuration FROM Jobs WHERE JobID = ?', $jobID);
 
-        if($row !== null) {
-            return json_decode($row['Configuration'],true);
+        if ($row !== null) {
+            return json_decode($row['Configuration'], true);
         } else {
             return [];
         }
@@ -342,10 +362,11 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Check if a lock for the doxygen process is present.
-     * 
+     *
      * @return Bool Is a lock present?
      */
-    private function _isRunning() {
+    private function isRunning()
+    {
         global $conf;
 
         $lock = $conf['lockdir'] . self::LOCKFILENAME;
@@ -355,23 +376,24 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Create a lock for the doxygen process.
-     * 
+     *
      * This is used for ensuring that only one doxygen process can be present at all times.
-     * 
+     *
      * If a lock is present we check if the lock file is older than the maximum allowed execution time
      * of the doxygen task runner. We then assume that the lock is stale and remove it.
-     * 
+     *
      * If a lock is present and not stale locking fails.
-     * 
+     *
      * @return Bool Was locking successful?
      */
-    private function _lock() {
+    private function lock()
+    {
         global $conf;
 
         $lock = $conf['lockdir'] . self::LOCKFILENAME;
 
         if (file_exists($lock)) {
-            if(time() - @filemtime($lock) > $this->getConf('runner_max_execution_time')) {
+            if (time() - @filemtime($lock) > $this->getConf('runner_max_execution_time')) {
                 // looks like a stale lock - remove it
                 unlink($lock);
             } else {
@@ -387,10 +409,11 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Remove the doxygen process lock file.
-     * 
+     *
      * @return Bool Was removing the lock successful?
      */
-    private function _unlock() {
+    private function unlock()
+    {
         global $conf;
         $lock = $conf['lockdir'] . self::LOCKFILENAME;
         return unlink($lock);
@@ -398,21 +421,22 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Execute a doxygen task runner build task.
-     * 
+     *
      * We obtain the build task from the Tasks table in sqlite.
      * The build task row includes used tag files from the snippet syntax.
-     * 
+     *
      * We then load the tag file configuration for those tag files and try to execute the build.
-     * 
+     *
      * After the doxygen process exited we update the build task state in sqlite.
-     * 
+     *
      * @param String $taskID TaskID for this build task
      * @return Bool Was building successful?
      */
-    public function runTask($taskID) {
+    public function runTask($taskID)
+    {
         global $conf;
 
-        if(!$this->_lock()) {
+        if (!$this->lock()) {
             // a task is already running
             return false;
         }
@@ -421,18 +445,18 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
         $row = $this->db->queryRecord('SELECT * FROM Tasks WHERE TaskID = ?', $taskID);
 
         // we only want to run if we have a scheduled job!
-        if($row === null || $row['State'] != self::STATE_SCHEDULED) {
-            $this->_unlock();
+        if ($row === null || $row['State'] != self::STATE_SCHEDULED) {
+            $this->unlock();
             return false;
         }
 
-        $config = json_decode($row['Configuration'],true);
+        $config = json_decode($row['Configuration'], true);
 
 
         /** @var helper_plugin_doxycode_tagmanager $tagmanager */
         $tagmanager = plugin_load('helper', 'doxycode_tagmanager');
         // load the tag_config from the tag file list
-        if(!is_array($config['tagfiles'])) {
+        if (!is_array($config['tagfiles'])) {
             $config['tagfiles'] = [$config['tagfiles']];
         }
         $tag_config = $tagmanager->getFilteredTagConfig($config['tagfiles']);
@@ -442,53 +466,60 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
         set_time_limit($this->getConf('runner_max_execution_time'));
 
         // this just returns the build dir if already existent
-        $tmpDir = $this->_createTaskDir($taskID);
+        $tmpDir = $this->createTaskDir($taskID);
 
         // update the task state
         // we do not update the timestamp of the task here
-        $this->db->exec('UPDATE Tasks SET State = ? WHERE TaskID = ?',
-        [self::STATE_RUNNING, $taskID]);
+        $this->db->exec(
+            'UPDATE Tasks SET State = ? WHERE TaskID = ?',
+            [self::STATE_RUNNING, $taskID]
+        );
 
         // execute doxygen and move cache files into position
-        $success = $this->_runDoxygen($tmpDir,$tag_config);
+        $success = $this->runDoxygen($tmpDir, $tag_config);
 
         // update the task state
-        if($success) {
-            $this->db->exec('UPDATE Tasks SET State = ? WHERE TaskID = ?',
-            [self::STATE_FINISHED, $taskID]);
+        if ($success) {
+            $this->db->exec(
+                'UPDATE Tasks SET State = ? WHERE TaskID = ?',
+                [self::STATE_FINISHED, $taskID]
+            );
         } else {
-            $this->db->exec('UPDATE Tasks SET State = ? WHERE TaskID = ?',
-            [self::STATE_ERROR, $taskID]);
+            $this->db->exec(
+                'UPDATE Tasks SET State = ? WHERE TaskID = ?',
+                [self::STATE_ERROR, $taskID]
+            );
         }
 
 
         // delete tmp_dir
-        if(!$conf['allowdebug']) {
-            $this->_deleteTaskDir($tmpDir);
+        if (!$conf['allowdebug']) {
+            $this->deleteTaskDir($tmpDir);
         }
 
-        $this->_unlock();
+        $this->unlock();
 
         return true;
     }
 
     /**
      * Execute doxygen in a shell.
-     * 
+     *
      * The doxygen configuration is passed to doxygen via a pipe and the TAGFILES parameter
      * is overridden with the tag file configuration passed to this function.
-     * 
+     *
      * In the xml output directory all matching XML output files are extracted and placed
      * where the other plugin components expect the XML cache file. This is done by extracting the XML
      * cache ID from the doxygen XML output filename (the source files in the doxygen directory where named
      * after the cache ID).
-     * 
+     *
      * @param String $build_dir Directory where doxygen should be executed.
      * @param Array $tag_conf Tag file configuration
      * @return Bool Was the execution successful?
      */
-    private function _runDoxygen($build_dir, $tag_conf = null) {
-        if(!is_dir($build_dir)) {
+    private function runDoxygen($build_dir, $tag_conf = null)
+    {
+        if (!is_dir($build_dir)) {
             // the directory does not exist
             return false;
         }
@@ -499,7 +530,8 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
         // TODO: check if doxygen executable exists!
 
         // Path to your Doxygen configuration file
-        // TODO: use default doxygen config or allow admin to upload a doxygen configuration that is not overwritten by plugin updates
+        // TODO: use default doxygen config or allow admin to upload
+        // a doxygen configuration that is not overwritten by plugin updates
         $doxygenConfig = DOKU_PLUGIN . $this->getPluginName() . '/doxygen.conf';
 
 
@@ -509,8 +541,8 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
         // TAGFILES variable value you want to set
         $tagfiles = '';
         $index = 0;
-        foreach($tag_conf as $key => $conf) {
-            if($index > 0) {
+        foreach ($tag_conf as $key => $conf) {
+            if ($index > 0) {
                 $tagfiles .= ' ';
             }
 
@@ -522,11 +554,15 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
 
         // Running the Doxygen command with overridden TAGFILES
-        exec("cd $build_dir && ( cat $doxygenConfig ; echo 'TAGFILES=$tagfiles' ) | $doxygenExecutable -", $output, $returnVar);
+        exec(
+            "cd $build_dir && ( cat $doxygenConfig ; echo 'TAGFILES=$tagfiles' ) | $doxygenExecutable -",
+            $output,
+            $returnVar
+        );
 
         // now extract the XML files from the build directory
         // Find all XML files in the directory
-        $files = glob($build_dir. '/xml/*_8*.xml');
+        $files = glob($build_dir . '/xml/*_8*.xml');
     
         foreach ($files as $file) {
             // Get the file name without extension
@@ -534,12 +570,12 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
             $cache_name = pathinfo($filename, PATHINFO_FILENAME);
 
-            $cache_name = explode('_8', $cache_name);;
+            $cache_name = explode('_8', $cache_name);
 
             // move XML to cache file position
-            $cache_name = getCacheName($cache_name[0],".xml");
+            $cache_name = getCacheName($cache_name[0], ".xml");
 
-            copy($file,$cache_name);
+            copy($file, $cache_name);
         }
 
         return $returnVar === 0;
@@ -547,34 +583,38 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
   
     /**
-     * The function _getXMLOutputName takes a filename in the Doxygen workspace and converts it to the output XML filename.
-     * TODO: can probably be deleted!
-     * 
+     * The function _getXMLOutputName takes a filename
+     * in the Doxygen workspace and converts it to the output XML filename.
+     *
+     * @todo: can probably be deleted!
+     *
      * @param string Name of a source file in the doxygen workspace.
-     * 
+     *
      * @return string Name of the XML file output by Doxygen for the given source file.
      */
-    private function _getXMLOutputName($filename) {
-        return str_replace(".","_8",$filename) . '.xml';
+    private function getXMLOutputName($filename)
+    {
+        return str_replace(".", "_8", $filename) . '.xml';
     }
 
     /**
      * The function creates a temporary directory for building the Doxygen documentation.
-     * 
+     *
      * @return string Directory where Doxygen can be executed.
      */
-    private function _createTaskDir($taskID) {
+    private function createTaskDir($taskID)
+    {
         global $conf;
 
         $tempDir = $conf['tmpdir'] . '/doxycode/';
 
         // check if we already have a doxycode directory
-        if(!is_dir($tempDir)) {
+        if (!is_dir($tempDir)) {
             mkdir($tempDir);
         }
     
         $tempDir .= $taskID;
-        if(!is_dir($tempDir)) {
+        if (!is_dir($tempDir)) {
             mkdir($tempDir);
         }
 
@@ -583,38 +623,40 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Delete the temporary build task directory.
-     * 
+     *
      * @param String $dirPath Build directory where doxygen is executed.
      */
-    private function _deleteTaskDir($dirPath) {
+    private function deleteTaskDir($dirPath)
+    {
         if (! is_dir($dirPath)) {
             throw new InvalidArgumentException("$dirPath must be a directory");
         }
 
-        io_rmdir($dirPath,true);
+        io_rmdir($dirPath, true);
     }
 
     /**
      * Create the source file in the build directory of the build task.
-     * 
+     *
      * The $config variable includes the corresponding TaskID.
      * First we try to create the temporary build directory.
-     * 
+     *
      * We than place the content of the code snippet in a source file in the build directory.
-     * 
+     *
      * The extension of the source file is the 'language' variable in $config.
      * The filename of the source file is the cache ID (=JobID) of the XML cache file.
      * This can later be used to place the doxygen output XML at the appropriate XML cache file name.
-     * 
+     *
      * @param String $jobID JobID for this build job
      * @param Array &$config Configuration from the snippet syntax
      * @param String $content Content from the code snippet
      */
-    private function _createJobFile($jobID,&$config,$content) {
+    private function createJobFile($jobID, &$config, $content)
+    {
         // if we do not already have a job directory, create it
-        $tmpDir = $this->_createTaskDir($config['taskID']);
+        $tmpDir = $this->createTaskDir($config['taskID']);
 
-        if(!is_dir($tmpDir)) {
+        if (!is_dir($tmpDir)) {
             return '';
         }
 
@@ -633,20 +675,24 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Get a list of scheduled build tasks from the Tasks table in sqlite.
-     * 
+     *
      * @param Num $amount Amount of build tasks to return.
      * @return Array Build tasks
      */
-    public function getBuildTasks($amount = PHP_INT_MAX) {
+    public function getBuildTasks($amount = PHP_INT_MAX)
+    {
         // get build tasks from SQLite
         // the order should be the same for all functions
         // first one is the one currently built or the next one do build
-        if($this->db === null) {
+        if ($this->db === null) {
             return false;
         }
 
         // get the oldest task first
-        $rows = $this->db->queryAll('SELECT TaskID FROM Tasks WHERE State = ? ORDER BY Timestamp ASC LIMIT ?', [self::STATE_SCHEDULED, $amount]);
+        $rows = $this->db->queryAll(
+            'SELECT TaskID FROM Tasks WHERE State = ? ORDER BY Timestamp ASC LIMIT ?',
+            [self::STATE_SCHEDULED, $amount]
+        );
     
 
         return $rows;
@@ -655,24 +701,25 @@ class helper_plugin_doxycode_buildmanager extends Plugin {
 
     /**
      * Filter the doxygen relevant attributes from a configuration array.
-     * 
+     *
      * The doxygen relevant attributes are parameters that are passed to doxygen when building.
      * Examples: tag file configuration
-     * 
+     *
      * The configuration also includes attributes that only influence task scheduling (e.g. 'render_task' which forces
      * task runner build from the syntax). Here we filter those values out.
-     * 
+     *
      * This function is especially useful for generating the cache file IDs.
-     * 
+     *
      * @param Array $config Configuration from the snippet syntax.
      * @param bool $exclude Return only doxygen relevant configuration or everying else
      * @return Array filtered configuration
      */
-    public function filterDoxygenAttributes($config, $exclude = false) {
+    public function filterDoxygenAttributes($config, $exclude = false)
+    {
         $filtered_config = [];
 
         // filter tag_config by tag_names
-        if(!$exclude) {
+        if (!$exclude) {
             $filtered_config = array_intersect_key($config, array_flip($this->conf_doxygen_keys));
         } else {
             $filtered_config = array_diff_key($config, array_flip($this->conf_doxygen_keys));

--- a/helper/parser.php
+++ b/helper/parser.php
@@ -189,7 +189,7 @@ class helper_plugin_doxycode_parser extends Plugin
 
         // match the external attribute to the tag file and extract the documentation URL
         foreach ($tag_conf as $key => $conf) {
-            if ($tagmanager->getTagFileDir() . $key . '.xml' === $external) {
+            if (realpath($tagmanager->getTagFileDir() . $key . '.xml') === $external) {
                 $output .= $conf['docu_url'];
                 break;
             }

--- a/helper/parser.php
+++ b/helper/parser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * DokuWiki Plugin doxycode (Parser Helper Component)
  *
@@ -6,20 +7,15 @@
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
 
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
+use dokuwiki\Extension\Plugin;
 
-
-use \dokuwiki\Extension\Plugin;
-
-class helper_plugin_doxycode_parser extends Plugin {
-
-
-    /** 
+class helper_plugin_doxycode_parser extends Plugin
+{
+    /**
      * @var Array $mapping Associative array that maps certain highlight classes in the
      * XML file to their corresponding DokuWiki CSS classes.
-     * 
-     * This mapping is used in the `renderXMLToDokuWikiCode()` method to convert the XML code to DokuWiki syntax. 
+     *
+     * This mapping is used in the `renderXMLToDokuWikiCode()` method to convert the XML code to DokuWiki syntax.
      */
     private $mapping = array(
         'comment' => 'co1',
@@ -32,17 +28,18 @@ class helper_plugin_doxycode_parser extends Plugin {
     /**
      * The function `renderXMLToDokuWikiCode` takes an XML string, line number setting, and tag
      * configuration as input and returns DokuWiki code.
-     * 
+     *
      * @param string A string containing XML code.
      * @param boolean A boolean value indicating whether line numbers should be included in the output
      * or not.
      * @param array The `tag_conf` parameter is an optional parameter that allows you to specify a
      * configuration for parsing specific XML tags. It is used in the `_parseDoxygenXMLElement` function,
      * which is called for each codeline element in the XML.
-     * 
+     *
      * @return string output string, which contains the DokuWiki code generated from the XML input.
      */
-    public function renderXMLToDokuWikiCode($xmlString,$line_numbers,$tag_conf = null) {
+    public function renderXMLToDokuWikiCode($xmlString, $line_numbers, $tag_conf = null)
+    {
         $output = '';
 
 
@@ -54,22 +51,22 @@ class helper_plugin_doxycode_parser extends Plugin {
         $programListing = $xpath->query('//programlisting')->item(0);
 
         // if linenumber setting is present output list elements around the codelines!
-        if($line_numbers) {
+        if ($line_numbers) {
             $output .= '<ol>';
             
             // $this->doc = str_replace("\n", "", $this->doc);
         }
 
         // loop over the codeline elements
-        foreach($programListing->childNodes as $codeline) {
-            if($codeline->hasChildNodes()) {
-                if($line_numbers) {
+        foreach ($programListing->childNodes as $codeline) {
+            if ($codeline->hasChildNodes()) {
+                if ($line_numbers) {
                     $output .= '<li class=\"li1\"><div>';
                 }
 
-                $this->_parseDoxygenXMLElement($codeline,$output,$tag_conf);
+                $this->parseDoxygenXMLElement($codeline, $output, $tag_conf);
 
-                if($line_numbers) {
+                if ($line_numbers) {
                     $output .= '</div></li>';
                 } else {
                     $output .= DOKU_LF;
@@ -77,30 +74,29 @@ class helper_plugin_doxycode_parser extends Plugin {
             }
         }
 
-
-        if($line_numbers) {
+        if ($line_numbers) {
             $output .= '</ol>';
         }
-
 
         return $output;
     }
 
     /**
      * Parse the children of codeline elements of a doxygen XML output and their children.
-     * 
+     *
      * Individual lines from a source file are converted to <codeline>...</codeline> elements by doxygen.
      * Here we parse the children of codeline elements and convert them to HTML elements that correspond
      * to the elements of a default dokuwiki code snippet.
-     * 
+     *
      * Some of the elements also contain children (e.g. <highlight ...><ref ...>...</ref>...</highlight>).
      * In those cases we recursivly call this function until no children are found.
-     * 
+     *
      * @param DOMElement $element Child element from the doxygen XML we want to parse
      * @param String &$output Reference to the output string we append the generated HTML to
      * @param Array $tag_conf Tag configuration used for generating the reference URLS
      */
-    private function _parseDoxygenXMLElement($element,&$output,$tag_conf = null) {
+    private function parseDoxygenXMLElement($element, &$output, $tag_conf = null)
+    {
         global $conf;
 
         // helper:
@@ -110,14 +106,16 @@ class helper_plugin_doxycode_parser extends Plugin {
 
         foreach ($element->childNodes as $node) {
             if ($node->nodeType === XML_ELEMENT_NODE) {
-
-                switch($node->nodeName) {
-                    /* The `case 'highlight'` matches the syntax highlighting elements inside the XML and matches these to dokuwiki CSS classes for code blocks. */
+                switch ($node->nodeName) {
+                    /**
+                     * The `case 'highlight'` matches the syntax highlighting elements inside
+                     * the XML and matches these to dokuwiki CSS classes for code blocks.
+                     */
                     case 'highlight':
                         $output .= '<span';
-                        if($node->hasAttribute('class')) {
+                        if ($node->hasAttribute('class')) {
                             $output .= ' class="';
-                            if($this->mapping[$node->getAttribute('class')] !== '') {
+                            if ($this->mapping[$node->getAttribute('class')] !== '') {
                                 $output .= $this->mapping[$node->getAttribute('class')];
                             } else {
                                 // if we cannot map a class from dokuwiki - just use the doxygen class for now
@@ -127,9 +125,9 @@ class helper_plugin_doxycode_parser extends Plugin {
                         }
                         $output .= '>';
                         // check if $element has children or content
-                        if($node->hasChildNodes()) {
+                        if ($node->hasChildNodes()) {
                             // parse the elements inside the span element
-                            $this->_parseDoxygenXMLElement($node,$output,$tag_conf);
+                            $this->parseDoxygenXMLElement($node, $output, $tag_conf);
                         }
                         $output .= '</span>';
                         break;
@@ -139,9 +137,9 @@ class helper_plugin_doxycode_parser extends Plugin {
                         break;
                     case 'ref':
                         $output .= "<a";
-                        if($node->hasAttribute('external') && $node->hasAttribute('refid')) {
+                        if ($node->hasAttribute('external') && $node->hasAttribute('refid')) {
                             $output .= ' href="';
-                            $output .= $this->_convertRefToURL($node,$tag_conf);
+                            $output .= $this->convertRefToURL($node, $tag_conf);
                             $output .= '" target="' . $conf['target']['extern'];
                             $output .= '"';
                         }
@@ -155,34 +153,32 @@ class helper_plugin_doxycode_parser extends Plugin {
             }
 
             // plain text inside an element is just appended to the document output
-            if($node->nodeType === XML_TEXT_NODE) {
+            if ($node->nodeType === XML_TEXT_NODE) {
                 $output .= $node->nodeValue;
             }
-
         }
-
     }
 
     /**
      * Convert the external reference from a doxygen XML to the documentation URL.
-     * 
+     *
      * The <ref...> element in the doxygen XML output includes the following elements:
      * - refid: page identifier + anchor to the element in the documentation
      * - external: name of the tag file of the documentation this reference points to
-     * 
+     *
      * The external attribute should match one of the tag file names we used when building the
      * documentation. We can use this attribute to find the tag file configuration, which in turn
      * includes the documentation base URL.
-     * 
+     *
      * We then convert the refid to a doxygen documentation html file name and append the anchor if
      * ther is one.
-     * 
+     *
      * @param DOMElement &$node reference to the XML reference element
      * @param Array $tag_conf Tag file configuration
      * @return String URL to the doxygen documentation for this reference
      */
-    private function _convertRefToURL(&$node,$tag_conf = null) {
-
+    private function convertRefToURL(&$node, $tag_conf = null)
+    {
         $output = '';
 
         $external = $node->getAttribute('external');
@@ -192,8 +188,8 @@ class helper_plugin_doxycode_parser extends Plugin {
         $tagmanager = plugin_load('helper', 'doxycode_tagmanager');
 
         // match the external attribute to the tag file and extract the documentation URL
-        foreach($tag_conf as $key => $conf) {
-            if($tagmanager->getTagFileDir() . $key . '.xml' === $external) {
+        foreach ($tag_conf as $key => $conf) {
+            if ($tagmanager->getTagFileDir() . $key . '.xml' === $external) {
                 $output .= $conf['docu_url'];
                 break;
             }
@@ -201,11 +197,11 @@ class helper_plugin_doxycode_parser extends Plugin {
 
         $kindref = '';
 
-        if($node->hasAttribute('kindref')) {
+        if ($node->hasAttribute('kindref')) {
             $kindref = $node->getAttribute('kindref');
         }
 
-        if($kindref === 'member') {
+        if ($kindref === 'member') {
             $lastUnderscorePos = strrpos($ref, '_');
 
             $first = substr($ref, 0, $lastUnderscorePos);

--- a/helper/tagmanager.php
+++ b/helper/tagmanager.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * DokuWiki Plugin doxycode (Tagmanager Helper Component)
  *
@@ -6,33 +7,31 @@
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
 
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC.'lib/plugins/');
+use dokuwiki\Extension\Plugin;
 
-
-use \dokuwiki\Extension\Plugin;
-
-class helper_plugin_doxycode_tagmanager extends Plugin {
-
+class helper_plugin_doxycode_tagmanager extends Plugin
+{
     private $tagfile_dir;   // convenience variable for accessing the tag files
 
-    function __construct() {
+    public function __construct()
+    {
         $this->tagfile_dir = DOKU_PLUGIN . $this->getPluginName() . '/tagfiles/';
     }
 
     /**
      * List tag files in the tag file directory.
-     * 
+     *
      * Returns an array with file names (without extension) as keys and empty
      * arrays as values. This ensures compatibility with the tag file configuration from loadTagFileConfig().
      * The list of tag files can then be merged with the tag file configuration.
-     * 
+     *
      * @return array associative array where the keys are the file names (without extension) of all XML files
      * in the directory, and the values are empty arrays.
      */
-    public function listTagFiles() {
+    public function listTagFiles()
+    {
         // Find all XML files in the directory
-        $files = glob($this->tagfile_dir. '*.xml');
+        $files = glob($this->tagfile_dir . '*.xml');
     
         // Array to hold file names without extension
         $fileNames = [];
@@ -45,7 +44,8 @@ class helper_plugin_doxycode_tagmanager extends Plugin {
         return array_fill_keys($fileNames, []);
     }
 
-    public function getTagFileDir() {
+    public function getTagFileDir()
+    {
         return $this->tagfile_dir;
     }
 
@@ -53,11 +53,12 @@ class helper_plugin_doxycode_tagmanager extends Plugin {
     /**
      * The function `loadTagFileConfig()` reads and decodes the contents of a JSON file containing tagfile
      * configuration, returning the decoded configuration array.
-     * 
+     *
      * @return array configuration array loaded from the tagconfig.json file. If the file does not exist or
      * if there is an error reading or decoding the JSON content, an empty array is returned.
      */
-    public function loadTagFileConfig() {
+    public function loadTagFileConfig()
+    {
         // /path/to/dokuwiki/lib/plugins/doxycode/tagfiles/
 
         $filename = $this->tagfile_dir . 'tagconfig.json';
@@ -85,12 +86,13 @@ class helper_plugin_doxycode_tagmanager extends Plugin {
 
     /**
      * The function checks if a directory exists and creates it if it doesn't.
-     * 
+     *
      * @return bool either the result of the `mkdir()` function if the directory does not exist and is
      * successfully created, or `true` if the directory already exists.
      */
-    public function createTagFileDir() {
-        if(!is_dir($this->tagfile_dir)) {
+    public function createTagFileDir()
+    {
+        if (!is_dir($this->tagfile_dir)) {
             return mkdir($this->tagfile_dir);
         } else {
             return true;
@@ -99,19 +101,29 @@ class helper_plugin_doxycode_tagmanager extends Plugin {
 
     /**
      * Save the tag file configuration as json in the tag file directory.
-     * 
-     * This function filters the relevant keys from the tag file configuration and saves all entries as a 'tagconfig.json' in the tag file directory.
-     * 
+     *
+     * This function filters the relevant keys from the tag file configuration
+     * and saves all entries as a 'tagconfig.json' in the tag file directory.
+     *
      * @param Array &$tag_config Array with tag file configuration entries.
-     * @param Bool $restore_mtime Restore the file modification time so that the cache files are not invalidated. Defaults to false.
+     * @param Bool $restore_mtime Restore the file modification time so
+     * that the cache files are not invalidated. Defaults to false.
      */
-    public function saveTagFileConfig(&$tag_config,$restore_mtime = false) {
+    public function saveTagFileConfig(&$tag_config, $restore_mtime = false)
+    {
         /** @var String[] $save_key_selection Configuration keys that are allowed in the stored configuration file. */
-        $save_key_selection = ['remote_url','update_period','docu_url','enabled','last_update','force_runner','description'];
+        $save_key_selection = [
+            'remote_url',
+            'update_period',
+            'docu_url',
+            'enabled',
+            'last_update',
+            'force_runner',
+            'description'];
 
         /**
          * @var String[] Copied tag file configuration entries.
-         * 
+         *
          * We copy over the allowed configuration $key => $value pairs so the original configuration is not modified.
          */
         $selected_config = [];
@@ -122,10 +134,10 @@ class helper_plugin_doxycode_tagmanager extends Plugin {
         $config_filename = $this->tagfile_dir . 'tagconfig.json';
 
         // loop over all configuration entries
-        foreach($tag_config as $name => $tag_conf) {
+        foreach ($tag_config as $name => $tag_conf) {
             // loop over all keys in configuration
-            foreach($tag_conf as $key => $value) {
-                if(in_array($key,$save_key_selection)) {
+            foreach ($tag_conf as $key => $value) {
+                if (in_array($key, $save_key_selection)) {
                     $selected_config[$name][$key] = $value;
                 }
             }
@@ -147,28 +159,30 @@ class helper_plugin_doxycode_tagmanager extends Plugin {
 
     /**
      * Convert the internal tag file name to a full file path with extension.
-     * 
+     *
      * @param String $tag_name Internal tag file name
      * @return String Full file path with extension for this tag file
      */
-    public function getFileName($tag_name) {
+    public function getFileName($tag_name)
+    {
         return $this->tagfile_dir . $tag_name . '.xml';
     }
 
     /**
      * Load the configuration of tag files and optionally filter them by names.
-     * 
+     *
      * @param String|Array $tag_names Internal tag file names (without extension) for filtering the configuration
      * @return Array Filtered tag file configuration
      */
-    public function getFilteredTagConfig($tag_names = null) {
+    public function getFilteredTagConfig($tag_names = null)
+    {
         $tag_conf = $this->loadTagFileConfig();
 
         // filter out tag files
-        $tag_conf = $this->filterConfig($tag_conf,'isConfigEnabled');
+        $tag_conf = $this->filterConfig($tag_conf, 'isConfigEnabled');
 
 
-        if($tag_names) {
+        if ($tag_names) {
             // convert to array if only one tag_name was given
             $tag_names = is_array($tag_names) ? $tag_names : [$tag_names];
 
@@ -181,17 +195,18 @@ class helper_plugin_doxycode_tagmanager extends Plugin {
 
     /**
      * Filter a tag file configuration array for entries that are enabled.
-     * 
+     *
      * @param Array &$tag_conf Array with tag file configuration entries.
      * @return Array Array with enabled tag file configuration entries.
      */
-    public function filterConfig($tag_config,$filter, $inverse = false) {
+    public function filterConfig($tag_config, $filter, $inverse = false)
+    {
         $filter = is_array($filter) ? $filter : [$filter];
 
         foreach ($filter as $function) {
             if ($inverse) {
                 // Apply the inverse filter
-                $tag_config = array_filter($tag_config, function($item) use ($function) {
+                $tag_config = array_filter($tag_config, function ($item) use ($function) {
                     return !$this->$function($item);
                 });
             } else {
@@ -204,55 +219,58 @@ class helper_plugin_doxycode_tagmanager extends Plugin {
 
     /**
      * Check if a tag file configuration is enabled.
-     * 
+     *
      * Tag file configurations can be disabled through the admin interface.
      * The parameters of the tag file (remote config, ...) will still be saved.
      * But the tag file can't be used.
-     * 
+     *
      * This function is used in @see filterEnabledConfig to filter a tag file configuration array for
      * entries that are enabled.
-     * 
+     *
      * @param Array &$tag_config Tag file configuration entry
      * @return bool Is this tag file configuration enabled?
      */
-    public function isConfigEnabled(&$tag_config) {
+    public function isConfigEnabled(&$tag_config)
+    {
         return boolval($tag_config['enabled']);
     }
 
     /**
      * Check if a tag file configuration represents a remote tag File
-     * 
+     *
      * @param Array &$tag_config Tag file configuration entry
      * @return bool Is this a remote tag file configuration?
      */
-    public function isValidRemoteConfig(&$tag_config) {
+    public function isValidRemoteConfig(&$tag_config)
+    {
 
         // TODO: should we check if the URL contains a valid XML extension?
         // TODO: should we also check if a valid period was set?
         // otherwise we could simply fall back to the default update period in the task runner action
-        if(strlen($tag_config['remote_url']) > 0) {
-            return True;
+        if (strlen($tag_config['remote_url']) > 0) {
+            return true;
         } else {
-            return False;
+            return false;
         }
     }
 
     /**
      * Check if a tag file configuration has the force runner flag enabled.
-     * 
+     *
      * Some tag files are huge and cause long building times.
      * We want to build the doxygen code snippet through the dokuwiki task runner in those cases.
      * Otherwise the loading time of the page might exceed the maximum php execution time.
      * This flag can be set through the admin interface.
-     * 
+     *
      * @param Array &$tag_config Tag file configuration entry
      * @return bool Is this the force runner flag enabled?
      */
-    public function isForceRenderTaskSet(&$tag_config) {
+    public function isForceRenderTaskSet(&$tag_config)
+    {
         $force_render = false;
-        foreach($tag_config as $key => $tag_conf) {
-            if($tag_conf['force_runner']) {
-                $force_render = True;
+        foreach ($tag_config as $key => $tag_conf) {
+            if ($tag_conf['force_runner']) {
+                $force_render = true;
                 break;
             }
         }

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -1,4 +1,5 @@
 <?php
+
 // Message texts for the dynamically loaded code snippets according to the state of the build task
 $lang['js']['msg_scheduled'] = 'The doxygen build has been scheduled. This state automatically updates!';
 $lang['js']['msg_running'] = 'The doxygen build is currently running. The snippet will automatically load after finishing!';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   doxycode
 author Lukas Probsthain
 email  lukas.probsthain@gmail.com
-date   2023-01-07
+date   2023-01-17
 name   DoxyCode Plugin
 desc   Parse code in dokuwiki with cross referencing to doxygen documentation.
 url    https://www.dokuwiki.org/plugin:doxycode

--- a/remote.php
+++ b/remote.php
@@ -1,7 +1,8 @@
 <?php
+
 /**
  * DokuWiki Plugin doxycode (Remote Component)
- * 
+ *
  * @license     GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
@@ -11,16 +12,15 @@ use dokuwiki\Remote\AccessDeniedException;
 
 /**
  * Class remote_plugin_doxycode
- * 
+ *
  * This remote component implements the following methods for the dokuwiki remote API:
  * - receive the current tag file configuration of doxycode
  * - upload a doxygen tag file (e.g. from a CI/CD pipeline)
- * 
+ *
  * @author      Lukas Probsthain <lukas.probsthain@gmail.com>
  */
 class remote_plugin_doxycode extends RemotePlugin
 {
-
     /**
      * Returns details about the remote plugin methods
      *
@@ -59,7 +59,7 @@ class remote_plugin_doxycode extends RemotePlugin
 
     /**
      * Upload a Doxycode Tag File
-     * 
+     *
      * The tag file will only be accepted if a configuration exists for it and if it is enabled.
      * Uploads for remote tag files will not be accepted
      *
@@ -67,7 +67,7 @@ class remote_plugin_doxycode extends RemotePlugin
      * @param string $file Contents of the doxygen tag file
      * @return bool If the upload was succesful
      */
-    public function uploadTagFile($filename,$file)
+    public function uploadTagFile($filename, $file)
     {
         $tagname = pathinfo($filename, PATHINFO_FILENAME);
 
@@ -77,13 +77,13 @@ class remote_plugin_doxycode extends RemotePlugin
         $tag_config = $tagmanager->loadTagFileConfig();
 
         // filter out disabled items
-        $tag_config = $tagmanager->filterConfig($tag_config,['isConfigEnabled']);
+        $tag_config = $tagmanager->filterConfig($tag_config, ['isConfigEnabled']);
 
         // filter out remote configurations (we do not allow uploading them)
-        $tag_config = $tagmanager->filterConfig($tag_config,['isValidRemoteConfig'],true);
+        $tag_config = $tagmanager->filterConfig($tag_config, ['isValidRemoteConfig'], true);
 
         // check file against existing configuration
-        if(!in_array($tagname,array_keys($tag_config))) {
+        if (!in_array($tagname, array_keys($tag_config))) {
             return array(false);
         }
 
@@ -95,20 +95,20 @@ class remote_plugin_doxycode extends RemotePlugin
         $existing_hash = '';
 
         $existing_file = $tagmanager->getFileName($tagname);
-        if(file_exists($existing_file)) {
+        if (file_exists($existing_file)) {
             $existing_content = @file_get_contents($existing_file);
     
             $existing_hash = md5($existing_content);
         }
         $new_hash = md5($file);
 
-        if($existing_hash !== $new_hash) {
+        if ($existing_hash !== $new_hash) {
             // move file into position
 
             // TODO: we should also check if we have a valid tag file on hand!
             // possibilities: parse XML, check project name (make setup more complicated!)
 
-            @file_put_contents($existing_file,$file);
+            @file_put_contents($existing_file, $file);
         }
         
         return array(true);

--- a/script.js
+++ b/script.js
@@ -13,6 +13,8 @@ jQuery(function(){
         STATE_ERROR: 5,
     };
 
+    var isLoadingSnippet = false;
+
     /**
      * Scan the document for doxycode markers that represent dynamically loaded code snippets.
      * 
@@ -164,6 +166,11 @@ jQuery(function(){
      * @author Lukas Probsthain <lukas.probsthain@gmail.com>
      */
     function loadSnippet(data) {
+        if (isLoadingSnippet) {
+            return;
+        }
+
+        isLoadingSnippet = true;
 
         jQuery.post(
             DOKU_BASE + 'lib/exe/ajax.php',
@@ -172,11 +179,13 @@ jQuery(function(){
                 hashes: data
             },
             function(response) {
+                isLoadingSnippet = false;
                 loadSnippetHtml(response);
             },
             'json'
         ).fail(function(jqXHR, textStatus, errorThrown) {
             console.error("AJAX error:", textStatus, errorThrown);
+            isLoadingSnippet = false;
         });
     }
 

--- a/syntax/snippet.php
+++ b/syntax/snippet.php
@@ -98,16 +98,21 @@ class syntax_plugin_doxycode_snippet extends SyntaxPlugin
         $remainingString = implode(' ', $parts);
     
         // Regular expression to match key="value" pairs and flag options
-        $pattern = '/(\w+)="([^"]*)"|(\w+)/';
+        $pattern = '/(\w+)=(?:"([^"]*)"|([^"\s]*))|(\w+)/';
         preg_match_all($pattern, $remainingString, $matches, PREG_SET_ORDER);
     
         foreach ($matches as $m) {
             if (!empty($m[1])) {
-                // This is a key="value" argument
-                $args[$m[1]] = $m[2];
-            } elseif (!empty($m[3])) {
+                if (!empty($m[2])) {
+                    // This is a key="value" argument
+                    $args[$m[1]] = $m[2];
+                } elseif (!empty($m[3])) {
+                    // This is a key=value argument
+                    $args[$m[1]] = $m[3];
+                }
+            } elseif (!empty($m[4])) {
                 // This is a flag option
-                $args[$m[3]] = 1;
+                $args[$m[4]] = 1;
             }
         }
 

--- a/syntax/taglist.php
+++ b/syntax/taglist.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * DokuWiki Plugin doxycode (Taglist Syntax Component)
  *
@@ -8,34 +9,35 @@
 
 use dokuwiki\Extension\SyntaxPlugin;
 
-// must be run within Dokuwiki
-if(!defined('DOKU_INC')) die();
-
 /**
  * Class syntax_plugin_doxycode_taglist
- * 
+ *
  * This syntax plugin renders a table with all available tag files.
  * It can be used to inform users which tag files can be used by which names in the snippet syntax.
  */
-class syntax_plugin_doxycode_taglist extends SyntaxPlugin {
-
-    public function getType() {
+class syntax_plugin_doxycode_taglist extends SyntaxPlugin
+{
+    public function getType()
+    {
         return 'substition';
     }
 
-    public function getSort() {
+    public function getSort()
+    {
         // TODO: which sort number?
         return 159;
     }
 
-    public function connectTo($mode) {
-        $this->Lexer->addSpecialPattern('<listtagfiles.*?/>',$mode,'plugin_doxycode_taglist');
+    public function connectTo($mode)
+    {
+        $this->Lexer->addSpecialPattern('<listtagfiles.*?/>', $mode, 'plugin_doxycode_taglist');
     }
 
-    public function handle($match, $state, $pos, Doku_Handler $handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler)
+    {
         static $args;
         switch ($state) {
-            case DOKU_LEXER_SPECIAL : 
+            case DOKU_LEXER_SPECIAL:
                 // TODO: do we expect parameters here?
                 // add columns like reload period, file state?
                 // TODO: implement option for only displaying enabled configurations!
@@ -48,10 +50,11 @@ class syntax_plugin_doxycode_taglist extends SyntaxPlugin {
     }
 
     /**
-     * 
+     *
      */
-    public function render($mode, Doku_Renderer $renderer, $data) {
-        if($mode != 'xhtml') return;
+    public function render($mode, Doku_Renderer $renderer, $data)
+    {
+        if ($mode != 'xhtml') return;
 
 
         /** @var helper_plugin_doxycode_tagmanager $tagmanager */
@@ -72,7 +75,7 @@ class syntax_plugin_doxycode_taglist extends SyntaxPlugin {
         $renderer->doc .= '</thead>';
 
         $renderer->doc .= '<tbody>';
-        foreach($config as $key => $conf) {
+        foreach ($config as $key => $conf) {
             $renderer->doc .= '<tr>';
             // TODO: display enabled state as locked checkbox
             $renderer->doc .= '<td>' . $conf['enabled'] . '</td>';


### PR DESCRIPTION
Main changes:
- apply dokuwiki PHP code style
- allow syntax attributes without quotes
  Before this change syntax attributes like 'language=c' (without quotes) resulted in an error.

Fixes:
- fix JavaScript requesting too many snippets
  Before this change the JavaScript dynamic loader was requesting too many snippets from the server if response time was slow.
- fix parser not matching tag file path with relative parts
  If the tag file path contained relative parts ('/path/to/dokuwiki/lib/exe/../../lib/plugins/doxycode/tagfiles/tagname.xml') the parser didn't match the tag files used in a doxygen XML output.
- fix snippet loader using the wrong cache file ID
  The HTML cacheID was used instead for generating the cache dependency of the HTML. Thereby invalidating the cache when requesting a code snippet via AJAX never resulted in parsing the new XML cache again.