### PR TITLE
Dev/lprobsth enhance

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   doxycode
 author Lukas Probsthain
 email  lukas.probsthain@gmail.com
-date   2023-01-17
+date   2023-01-21
 name   DoxyCode Plugin
 desc   Parse code in dokuwiki with cross referencing to doxygen documentation.
 url    https://www.dokuwiki.org/plugin:doxycode

--- a/syntax/snippet.php
+++ b/syntax/snippet.php
@@ -323,7 +323,7 @@ class syntax_plugin_doxycode_snippet extends SyntaxPlugin
                             }
                         }
 
-                        $renderer->doc .= '</div';
+                        $renderer->doc .= '</div>';
                     } else {
                         // if buildsuccess==true we want to parse the XML now
                         $job_state = helper_plugin_doxycode_buildmanager::STATE_FINISHED;


### PR DESCRIPTION
Fixes:
- fix broken page structure because of missing closing tag
  The <div> element for the doxycode marker (used for dynamically loading code snippets that are build through the task runner) was not properly closed braking the page layout.