### PR TITLE
Dev/lprobsth enhance

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -8,3 +8,4 @@
 $conf['default_update_period']    = 300;
 $conf['runner_max_execution_time']    = 30;
 $conf['runner_max_tasks']    = 5;
+$conf['doxygen_executable'] = '/usr/bin/doxygen';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,3 +8,4 @@
 $meta['default_update_period']    = array('numeric');
 $meta['runner_max_execution_time']    = array('numeric');
 $meta['runner_max_tasks']    = array('numeric');
+$meta['doxygen_executable'] = array('string');

--- a/helper/buildmanager.php
+++ b/helper/buildmanager.php
@@ -214,7 +214,7 @@ class helper_plugin_doxycode_buildmanager extends Plugin
         }
 
         // run doxygen on our file with XML output
-        $this->runDoxygen($tmp_dir, $tag_conf);
+        $buildsuccess = $this->runDoxygen($tmp_dir, $tag_conf);
 
         // delete tmp_dir
         if (!$conf['allowdebug']) {
@@ -224,7 +224,7 @@ class helper_plugin_doxycode_buildmanager extends Plugin
 
         $this->unlock();
 
-        return true;
+        return $buildsuccess;
     }
 
     /**

--- a/helper/buildmanager.php
+++ b/helper/buildmanager.php
@@ -524,10 +524,12 @@ class helper_plugin_doxycode_buildmanager extends Plugin
             return false;
         }
 
-        // TODO: add plugin configuration for setting the path
-        $doxygenExecutable = '/usr/bin/doxygen';
+        $doxygenExecutable = $this->getConf('doxygen_executable');
 
-        // TODO: check if doxygen executable exists!
+        // check if doxygen executable exists!
+        if (!file_exists($doxygenExecutable)) {
+            return false;
+        }
 
         // Path to your Doxygen configuration file
         // TODO: use default doxygen config or allow admin to upload

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -3,3 +3,4 @@
 $lang['default_update_period'] = 'Default update period for remote cache files. After this period doxycode tries to download the tag file from the remote source and compares it to the local version. This might be overwritten by the tag configuration (see admin page).';
 $lang['runner_max_execution_time'] = 'Maximum execution time for a doxygen process executed through the task runner.';
 $lang['runner_max_tasks'] = 'Maximum amount of tasks to run in one task runner instance. This setting can be used to prevent the background building of code snippets from running too long.';
+$lang['doxygen_executable'] = 'Path of the doxygen executable.';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   doxycode
 author Lukas Probsthain
 email  lukas.probsthain@gmail.com
-date   2023-01-21
+date   2023-02-16
 name   DoxyCode Plugin
 desc   Parse code in dokuwiki with cross referencing to doxygen documentation.
 url    https://www.dokuwiki.org/plugin:doxycode


### PR DESCRIPTION
Main changes:
- make doxygen executable configurable
- handle build fail gracefully
  Before this change no feedback from the build execution function was processed - the function always returned a successful build. This caused the plugin loading the cached version of the snippet even when the build failed.