### PR TITLE
handle corrup entries in the task table better

### DIFF
--- a/helper/buildmanager.php
+++ b/helper/buildmanager.php
@@ -692,7 +692,7 @@ class helper_plugin_doxycode_buildmanager extends Plugin
 
         // get the oldest task first
         $rows = $this->db->queryAll(
-            'SELECT TaskID FROM Tasks WHERE State = ? ORDER BY Timestamp ASC LIMIT ?',
+            'SELECT TaskID FROM Tasks WHERE TaskID IS NOT NULL AND State = ? ORDER BY Timestamp ASC LIMIT ?',
             [self::STATE_SCHEDULED, $amount]
         );
     


### PR DESCRIPTION
Fixes:
- handle corrup entries in the task table better
  Sometimes tasks are not properly inserted into the tasks table - this handles those entries. Later on we will implement a cleanup function that removes corrupt or old entries from the sqlite table.